### PR TITLE
DGS-440: added second filter form to form-mappings

### DIFF
--- a/constants/form-mappings.js
+++ b/constants/form-mappings.js
@@ -1,4 +1,5 @@
 export const FORMS = {
   'ebd65df9-5566-47c2-859a-ceff562881ab': 'share://search-query/config-form.ttl',
-  'e025a601-b50b-4abd-a6de-d0c3b619795c': 'share://search-query/filter-form.ttl'
+  'e025a601-b50b-4abd-a6de-d0c3b619795c': 'share://search-query/filter-form.ttl',
+  'e025a601-b50b-4abd-a6de-d0c3b619795d': 'share://search-query/filter-form2.ttl'
 };


### PR DESCRIPTION
Added a second form mapping so that two can be defined in subsidiepunt backend. One for subsidiepunt and one for subsidiedatabank.